### PR TITLE
hotfix: deal with our cluster's weird tmpdir rules

### DIFF
--- a/workflow/rules/RGI.smk
+++ b/workflow/rules/RGI.smk
@@ -33,7 +33,7 @@ rule RGI:
         )[0],
         CARD_VER=os.path.basename(os.path.dirname(config["CARD_db_json"])),
         CARD_DB_DIR=lambda wildcards, input: os.path.dirname(input["db"]),
-        tmpdir=os.environ["TMPDIR"],
+        tmpdir="rgitmp",
     conda:
         "../envs/RGI.yaml"
     container:
@@ -48,6 +48,7 @@ rule RGI:
     shell:
         """
         # RGI uses samtools which will use TMPDIR. here we make sure that exists
+        # on our cluster, certain nodes appear to have
         mkdir -p {params.tmpdir}
         # --wildcard_index {params.CARD_DB_DIR}/wildcard/index-for-model-sequences.txt
         # --wildcard_annotation {params.CARD_DB_DIR}/wildcard_database_{params.CARD_VER}.fasta
@@ -63,6 +64,7 @@ rule RGI:
             --output_file {params.outpre} --threads {threads} \
             --local --clean
         ls rgi
+        rm -r {params.tmpdir}
         """
 
 


### PR DESCRIPTION
There is a bit of  an issue using TMPDIR, which we are requested to set to /scratch/username.  When running containerized rules, TMPDIR needs to be bound. However, this directory does not exists by default on all the nodes of the cluster. When this happens, you get:
```WARNING: skipping mount of /scratch/watersn: stat /scratch/watersn: no such file or directory```
And because this is per node, we can't create the directory ahead of time without modifying the lsf submission script.  This PR makes and cleans up a tmpdir within the RGI working directory.