### PR TITLE
Hotfix/catch bad clumpifying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tmp*
 .Rproj.user
 msk-lsf/__pycache__
 vdb_16S/test_output/
+tests/__pycache__/

--- a/development.md
+++ b/development.md
@@ -24,6 +24,15 @@ This is a stool shotgun sequencing run deposited on SRA.  It is small but closer
 ## The test script
 Currently the script `test.sh` contains logic to run different pipeline stages.
 
+## Testing python logic
+For python function contained in the `workflow/rules/common.smk` snakefile, we have added a test script `tests/test_common.py`.  To add tests to code, use [pytest](https://docs.pytest.org/en/7.2.x/) syntax.  In short, make a function starting with `test_` with some assertions about expected results.  execute the tests with:
+
+```sh
+pytest --capture=no   tests/test_common.py
+```
+
+The `--capture=no` allows us to see print statements.
+
 #### USAGE:
 
 ```sh

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -7,9 +7,14 @@ from pathlib import Path
 # importlib
 import types
 import importlib.machinery
-loader = importlib.machinery.SourceFileLoader('common', 'workflow/rules/common.smk')
+
+loader = importlib.machinery.SourceFileLoader("common", "workflow/rules/common.smk")
 mod = types.ModuleType(loader.name)
 loader.exec_module(mod)
 
 sys.modules["common"] = mod
 from common import *
+
+# TODO: many of the snakemake input/param functions rely on accessing `config`
+# from the global namespace. That won't work defining that globally in this
+# test module because the imported modules have a different namespace.

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+# this allows us to import files without the .py extension
+# I don't entirely understand the need for types, but it seems
+# like that is needed since the migration from imp to
+# importlib
+import types
+import importlib.machinery
+loader = importlib.machinery.SourceFileLoader('common', 'workflow/rules/common.smk')
+mod = types.ModuleType(loader.name)
+loader.exec_module(mod)
+
+sys.modules["common"] = mod
+from common import *

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -228,7 +228,6 @@ if config["stage"] == "all":
         wildcard_constraints:
             sample=".+(?<!shard\d\d\d)",
 
-
 else:
     pass
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -228,6 +228,7 @@ if config["stage"] == "all":
         wildcard_constraints:
             sample=".+(?<!shard\d\d\d)",
 
+
 else:
     pass
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -79,9 +79,9 @@ def test_bbmap_dedup_params_flags():
         [{"dedup_platform": "NovaSeq"}, "dedupe optical dupedist=12000"],
         [{"dedup_platform": "NextSeq"}, "dedupe optical spany adjacent dupedist=40"],
         [{"dedup_platform": "HiSeq-3000"}, "dedupe optical dupedist=2500"],
-        [{"dedup_platform": "HiSeq-4000"}, "dedupe optical dupedist=2500"]
+        [{"dedup_platform": "HiSeq-4000"}, "dedupe optical dupedist=2500"],
     ]
-    for i  in test_conditions:
+    for i in test_conditions:
         global config
         config = i[0]
         outcome = i[1]

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -50,6 +50,9 @@ def bbmap_dedup_params_flags(wildcards):
         # try to parse the SRA names for optical deduplication
         if config["dedup_platform"] == "SRA":
             flags = "dedupe"
+        else:
+            dupedist = bbmap_dedup_params_dupedist(wildcards)
+            flags += f" dupedist={dupedist}"
     return flags
 
 
@@ -67,6 +70,23 @@ def bbmap_dedup_params_dupedist(wildcards):
         dupedist = 2500
 
     return dupedist
+
+
+def test_bbmap_dedup_params_flags():
+    test_conditions = [
+        [{"dedup_platform": "SRA"}, "dedupe"],
+        [{"dedup_platform": "MiniSeq"}, "dedupe optical dupedist=40"],
+        [{"dedup_platform": "NovaSeq"}, "dedupe optical dupedist=12000"],
+        [{"dedup_platform": "NextSeq"}, "dedupe optical spany adjacent dupedist=40"],
+        [{"dedup_platform": "HiSeq-3000"}, "dedupe optical dupedist=2500"],
+        [{"dedup_platform": "HiSeq-4000"}, "dedupe optical dupedist=2500"]
+    ]
+    for i  in test_conditions:
+        global config
+        config = i[0]
+        outcome = i[1]
+        assert bbmap_dedup_params_flags(None) == outcome
+        print(f"passed dedup flags test for {config['dedup_platform']}")
 
 
 # Kraken functions

--- a/workflow/rules/preprocess.smk
+++ b/workflow/rules/preprocess.smk
@@ -120,7 +120,6 @@ rule bbmap_dedup:
     params:
         allowed_subs=3,
         flags=bbmap_dedup_params_flags,
-        dupedist=bbmap_dedup_params_dupedist,
     resources:
         mem_mb=lambda wildcards, input, attempt: attempt
         * (max(input.size // 1000000, 1024) * 16),
@@ -141,7 +140,6 @@ rule bbmap_dedup:
             out1={output.R1} out2={output.R2} \
             {params.flags} \
             subs={params.allowed_subs} \
-            dupedist={params.dupedist} \
             t={threads} \
             -Xmx{resources.mem_mb}M \
             -eoom \
@@ -153,10 +151,19 @@ rule bbmap_dedup:
             sed "s|\: *|\t|g" \
             >> {output.dedup_stats}
 
+        # clumpty tends to fail silently. We both catch general cases resulting in an empty file
+        # and cases of misspecified platform (eg trying to do optical deduplicaiton on SRA samples without coordinates)
         if [ ! -s "{output.R1}" ]
         then
-           echo "output file after dedup is empty"
-           exit 1
+          echo "output file after dedup is empty"
+          exit 1
+        else
+          nlines=$(zcat {output.R1} | wc -l)
+          if [ "$nlines" -lt 4 ]
+          then
+            echo "output file after dedup is empty"
+            exit 1
+          fi
         fi
         """
 

--- a/workflow/rules/preprocess.smk
+++ b/workflow/rules/preprocess.smk
@@ -151,8 +151,8 @@ rule bbmap_dedup:
             sed "s|\: *|\t|g" \
             >> {output.dedup_stats}
 
-        # clumpty tends to fail silently. We both catch general cases resulting in an empty file
-        # and cases of misspecified platform (eg trying to do optical deduplicaiton on SRA samples without coordinates)
+        # clumpify tends to fail silently. We both catch general cases resulting in an empty file
+        # and cases of misspecified platform (eg trying to do optical deduplication on SRA samples without coordinates)
         if [ ! -s "{output.R1}" ]
         then
           echo "output file after dedup is empty"


### PR DESCRIPTION
This resolves cryptic errors that cause bbmap clumpify to hang:
```
Exception in thread "Thread-19" java.lang.AssertionError: SRR21986403.401 401 length=151
        at hiseq.FlowcellCoordinate.setFrom(FlowcellCoordinate.java:53)
        at clump.ReadKey.<init>(ReadKey.java:46)
        at clump.ReadKey.<init>(ReadKey.java:33)
        at clump.ReadKey.makeKey(ReadKey.java:23)
        at clump.KmerComparator.hash_inner(KmerComparator.java:78)
        at clump.KmerComparator.hash(KmerComparator.java:69)
        at clump.KmerComparator.hash(KmerComparator.java:65)
        at clump.KmerSplit$HashThread.run(KmerSplit.java:446)
```
which stems from not having tile info in the fastq header.  This is mostly relevant for test data, but will also be relevant for running HMP2 samples or other samples with non-standard Illumina fastq headers.

I added a test script that we can expand for more functions in the `common.smk`.  Its ugly because you can't directly use pytest on files that don't end in `.py`. 

