### PR TITLE
Fix/hlatyping

### DIFF
--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -23,7 +23,7 @@ properties:
     uniqueItems: true
   stage:
     type: string
-    pattern: "^(all|biobakery|preprocess|assembly|rgi|kraken|binning|annotate|downsample)$"
+    pattern: "^(all|biobakery|preprocess|assembly|rgi|kraken|binning|annotate|downsample|hla)$"
   # run parameters
   nshards:
     type: integer

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -19,6 +19,9 @@ bowtie2_mouse_index_base: "/data/brinkvd/resources/indexes/mouse/GRCm39/GCA_0000
 snap_human_index_dir: "/data/brinkvd/resources/indexes/human/CHM13/v2.0/snap/chm13v2.0.fa.gz/"
 snap_mouse_index_dir: "/data/brinkvd/resources/indexes/mouse/GRCm39/GCA_000001635.9/snap/GCA_000001635.9_GRCm39_genomic.fna.gz/"
 
+## optityper
+
+
 
 ## 16S annotation
 blast_16s_db_nsq: "/data/brinkvd/resources/dbs/ncbi16S/2022/16S_ribosomal_RNA.nsq"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -20,7 +20,8 @@ snap_human_index_dir: "/data/brinkvd/resources/indexes/human/CHM13/v2.0/snap/chm
 snap_mouse_index_dir: "/data/brinkvd/resources/indexes/mouse/GRCm39/GCA_000001635.9/snap/GCA_000001635.9_GRCm39_genomic.fna.gz/"
 
 ## optityper
-
+optityper_hla_dna: "/data/brinkvd/resources/references/human/optitype-hla-dna/07c49bf6fc/hla_reference_dna.fasta"
+optityper_hla_rna: "/data/brinkvd/resources/references/human/optitype-hla-rna/07c49bf6fc/hla_reference_rna.fasta"
 
 
 ## 16S annotation

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -222,6 +222,7 @@ if config["stage"] == "all":
         input:
             R1="host/{sample}_all_host_reads_R1.fastq.gz",
             R2="host/{sample}_all_host_reads_R2.fastq.gz",
+            alleles=config["optityper_hla_dna"],
 
     use rule SPAdes_run from assembly as assembly_SPAdes_run with:
         input:
@@ -287,6 +288,7 @@ outputs = {
         rules.rgi_all.input,
         rules.binning_all.input,
         rules.annotate_all.input,
+        rules.hla_all.input,
     ],
     "preprocess": [
         rules.preprocess_all.input,

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -279,6 +279,7 @@ else:
 # the above else: pass is needed to make snakefmt happy
 
 
+# in "all" mode, we do NOT HLA type as we regularly lack sufficient host depth
 outputs = {
     "all": [
         rules.preprocess_all.input,
@@ -288,7 +289,7 @@ outputs = {
         rules.rgi_all.input,
         rules.binning_all.input,
         rules.annotate_all.input,
-        rules.hla_all.input,
+        # rules.hla_all.input,
     ],
     "preprocess": [
         rules.preprocess_all.input,

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -180,6 +180,21 @@ module downsample:
 use rule * from downsample as downsample_*
 
 
+#
+# hla Module
+#
+module hla:
+    snakefile:
+        "rules/HLA.smk"
+    config:
+        config
+    skip_validation:
+        True
+
+
+use rule * from hla as hla_*
+
+
 """
 Notes:
 put all the logic here to connect pipeline stages (eg setting biobakery to using preprocessed results rather than config's R1 and R2
@@ -202,6 +217,11 @@ if config["stage"] == "all":
             R1="hostdepleted/{sample}_R1.fastq.gz",
             R2="hostdepleted/{sample}_R2.fastq.gz",
             db=config["CARD_db_json"],
+
+    use rule OptiType_subset_fastq from hla as hla_OptiType_subset_fastq with:
+        input:
+            R1="host/{sample}_all_host_reads_R1.fastq.gz",
+            R2="host/{sample}_all_host_reads_R2.fastq.gz",
 
     use rule SPAdes_run from assembly as assembly_SPAdes_run with:
         input:
@@ -291,6 +311,9 @@ outputs = {
     ],
     "downsample": [
         rules.downsample_all.input,
+    ],
+    "hla": [
+        rules.hla_all.input,
     ],
 }
 

--- a/workflow/rules/HLA.smk
+++ b/workflow/rules/HLA.smk
@@ -3,13 +3,17 @@ from snakemake.remote.HTTP import RemoteProvider as HTTPRemoteProvider
 from snakemake.utils import validate
 
 HTTP = HTTPRemoteProvider()
+
+
 configfile: os.path.join(str(workflow.current_basedir), "../../config/config.yaml")
+
 
 validate(config, os.path.join(str(workflow.basedir), "../../config/config.schema.yaml"))
 
+
 rule all:
     input:
-        expand("reports/{sample}_result.tsv", sample=config['sample'])
+        expand("reports/{sample}_result.tsv", sample=config["sample"]),
 
 
 rule OptiType_subset_fastq:
@@ -32,15 +36,16 @@ rule OptiType_subset_fastq:
         razers3 -i 95 -m 1 -dr 0 -o {output.R2} {input.alleles} {input.R2}
         """
 
+
 rule OptiType_bam2fastq:
     """the bam is converted to a single fastq.
     Optityper does not used the pairing information
     """
     input:
-        R1="tmp_optitype_{sample}_R1.bam",
-        R2="tmp_optitype_{sample}_R2.bam",
+        R1="razor/tmp_optitype_{sample}_R1.bam",
+        R2="razor/tmp_optitype_{sample}_R2.bam",
     output:
-        R1=temp("tmp_optitype_{sample}.fastq"),
+        R1=temp("razor/tmp_optitype_{sample}.fastq"),
     container:
         config["docker_bowtie2"]
     threads: 16
@@ -50,9 +55,10 @@ rule OptiType_bam2fastq:
         samtools bam2fq {input.R2} >> {output.R1}
         """
 
+
 rule OptiType_fastq:
     input:
-        R1="tmp_optitype_{sample}.fastq",
+        R1="razor/tmp_optitype_{sample}.fastq",
     output:
         results="reports/{sample}_result.tsv",
     container:

--- a/workflow/rules/HLA.smk
+++ b/workflow/rules/HLA.smk
@@ -21,8 +21,8 @@ rule OptiType_subset_fastq:
         R2=config["R2"],
         alleles=config["optityper_hla_dna"],
     output:
-        R1=temp("tmp_optitype_{sample}_R1.bam"),
-        R2=temp("tmp_optitype_{sample}_R2.bam"),
+        R1=temp("razor/tmp_optitype_{sample}_R1.bam"),
+        R2=temp("razor/tmp_optitype_{sample}_R2.bam"),
     container:
         config["docker_optitype"]
     threads: 16

--- a/workflow/rules/HLA.smk
+++ b/workflow/rules/HLA.smk
@@ -32,8 +32,12 @@ rule OptiType_subset_fastq:
     threads: 16
     shell:
         """
-        razers3 -i 95 -m 1 -dr 0 -o {output.R1} {input.alleles} {input.R1}
-        razers3 -i 95 -m 1 -dr 0 -o {output.R2} {input.alleles} {input.R2}
+        razers3 --percent-identity 95 --thread-count {threads} \
+           --max-hits 1 --distance-range 0 --output {output.R1} \
+            {input.alleles} {input.R1}
+        razers3 --percent-identity 95 --thread-count {threads} \
+           --max-hits 1 --distance-range 0 --output {output.R2} \
+            {input.alleles} {input.R2}
         """
 
 
@@ -48,7 +52,7 @@ rule OptiType_bam2fastq:
         R1=temp("razor/tmp_optitype_{sample}.fastq"),
     container:
         config["docker_bowtie2"]
-    threads: 16
+    threads: 1
     shell:
         """
         samtools bam2fq {input.R1} > {output.R1}
@@ -63,7 +67,7 @@ rule OptiType_fastq:
         results="reports/{sample}_result.tsv",
     container:
         config["docker_optitype"]
-    threads: 16
+    threads: 1
     shell:
         """
         if [ -s "{input.R1}" ];

--- a/workflow/rules/HLA.smk
+++ b/workflow/rules/HLA.smk
@@ -1,73 +1,60 @@
+import os
+from snakemake.remote.HTTP import RemoteProvider as HTTPRemoteProvider
+from snakemake.utils import validate
+
+HTTP = HTTPRemoteProvider()
+configfile: os.path.join(str(workflow.current_basedir), "../../config/config.yaml")
+
+validate(config, os.path.join(str(workflow.basedir), "../../config/config.schema.yaml"))
+
 rule all:
     input:
-        f"reports/optitype_result.tsv",
+        expand("reports/{sample}_result.tsv", sample=config['sample'])
 
 
-# rule sort_index:
-#     input:
-#         bam=config["bam"],
-#     output:
-#         results=temp(f"{os.path.basename(config['bam'])}.bai"),
-#         bam=temp(f"{os.path.basename(config['bam'])}"),
-#     container: config["docker_bowtie2"],
-#     threads: 8
-#     shell:
-#         """
-#         samtools view -bh -F 4 {input.bam} | samtools  sort -@ {threads} -o {output.bam} -O bam -
-#         samtools index -@ {threads} {output.bam}
-#         """
-
-# rule xHLA:
-#     """ Couldn't get this to work, got error where the tsv file was empty.  Perhaps too few reads?  Similar to https://github.com/humanlongevity/HLA/issues/62"""
-#     input:
-#         results=f"{os.path.basename(config['bam'])}.bai",
-#         bam=f"{os.path.basename(config['bam'])}",
-#     output:
-#         results=f"xHLA/{os.path.basename(config['bam'])}.json",
-#     container: config["docker_hla"]
-#     threads: 4
-#     resources:
-#         mem_mb=1024*16,
-#         runtime="12:00",
-#     params:
-#         sample=os.path.basename(config['bam']),
-#     shell:
-#         """ run.py \
-#         --sample_id {params.sample} --input_bam_path {input.bam} \
-#         --output_path xHLA
-#         find .
-#         """
-
-# rule OptiType:
-#     """ Couldn't get this to work from BAM, perhaps an issue with the reference or with BWA vs bowtie?  the Bam input is intended for rerunning optityper, not neccessaritly to go straight from an existing alignment. see allso https://github.com/FRED-2/OptiType/issues/64"""
-#     input:
-#         results=f"{os.path.basename(config['bam'])}.bai",
-#         bam=f"{os.path.basename(config['bam'])}",
-#     output:
-#         results=f"optitype/{os.path.basename(config['bam'])}.json",
-#     container:
-#         "docker://fred2/optitype"
-#     threads: 16
-#     shell:"""
-#     OptiTypePipeline.py -i {input.bam} --dna -o optitype -v
-#     find optitype
-#     """
-
-
-rule OptiType_fastq:
+rule OptiType_subset_fastq:
     input:
         R1=config["R1"],
         R2=config["R2"],
+        alleles=HTTP.remote("https://raw.githubusercontent.com/FRED-2/OptiType/master/data/hla_reference_dna.fasta")
     output:
-        results=f"optitype_fastq/optitype_result.tsv",
+        R1="tmp_{sample}_R1.bam",
+        R2="tmp_{sample}_R2.bam",
     container:
         config["docker_optitype"]
-    params:
-        #        sample=os.path.splitext(os.path.basename(config['R1'][0]))[0]
-        sample="optitype",
     threads: 16
     shell:
         """
-        OptiTypePipeline.py -i {input.R1} {input.R2} --dna --prefix {params.sample} --outdir reports/ --verbose
-        find reports
+        razers3 -i 95 -m 1 -dr 0 -o {output.R1} {input.alleles} {input.R1}
+        razers3 -i 95 -m 1 -dr 0 -o {output.R2} {input.alleles} {input.R2}
+        """
+
+rule OptiType_bam2fastq:
+    input:
+        R1="tmp_{sample}_R1.bam",
+        R2="tmp_{sample}_R2.bam",
+    output:
+        R1="tmp_{sample}.fastq",
+    container:
+        config["docker_bowtie2"]
+    threads: 16
+    shell:
+        """
+        samtools bam2fq {input.R1} > {output.R1}
+        samtools bam2fq {input.R2} >> {output.R1}
+        """
+
+rule OptiType_fastq:
+    # TODO move ref to resources repo
+    input:
+        R1="tmp_{sample}.fastq",
+    output:
+        results="reports/{sample}_result.tsv",
+    container:
+        config["docker_optitype"]
+    threads: 16
+    shell:
+        """
+        OptiTypePipeline.py -i {input.R1}  --dna --prefix {wildcards.sample} --outdir reports/ --verbose
+        find .
         """

--- a/workflow/rules/RGI.smk
+++ b/workflow/rules/RGI.smk
@@ -64,7 +64,7 @@ rule RGI:
             --output_file {params.outpre} --threads {threads} \
             --local --clean
         ls rgi
-        rm -r {params.tmpdir}
+        rm -r {params.tmpdir} localDB/
         """
 
 


### PR DESCRIPTION
This addresses issues #9, #25, and #28.  Jury is still out on #29.

Additionally, this removes the expectation for an HLA output in the preprocessing results.  Ancedotaly, with one abnormal sample having ~41M host reads (over 55% of the sample), the optityper scheme only recovered 263 HLA reads.  For normal stool samples the likelihood of having enough host reads to determine the HLA  type is very low.  

Because this is removing an output, I'm adding this as a pr for the 0.4.0 release