### PR TITLE
temp uncompressed unclassified fastqs, and fix cases with exact read lengths for bracken

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -130,7 +130,7 @@ def parse_read_lengths(wildcards):
             Path(thispath).touch()
             final_basenames.append(os.path.basename(thispath))
         else:
-            final_basenames.append(f"len{closest_read_length}")
+            final_basenames.append(f"len{readlen}")
 
     return expand(os.path.join(ck_output, "{basenames}"), basenames=final_basenames)
 

--- a/workflow/rules/kraken.smk
+++ b/workflow/rules/kraken.smk
@@ -105,8 +105,8 @@ rule kraken_standard_run:
         db=config["kraken2_db"],
     output:
         out="kraken2/{sample}_kraken2.out",
-        unclass_R1="kraken2/{sample}_kraken2_unclassified_1.fastq",
-        unclass_R2="kraken2/{sample}_kraken2_unclassified_2.fastq",
+        unclass_R1=temp("kraken2/{sample}_kraken2_unclassified_1.fastq"),
+        unclass_R2=temp("kraken2/{sample}_kraken2_unclassified_2.fastq"),
         report="kraken2/{sample}_kraken2.report",
     params:
         unclass_template=lambda wildcards, output: output["unclass_R1"].replace(


### PR DESCRIPTION
This temp-ifies the kraken unclassified reads, and fixes a bug for cases where the closest read length calculations are uneccessary