### PR TITLE
Fix/downsample multiple fastqs

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -19,6 +19,13 @@ case $rawdataset in
 	R2=[${PWD}/.test/SRR18369973/SRR18369973_2.fastq.gz]
 	addnconf="dedup_platform=SRA"
 	;;
+    multilib)
+	# this is to test handling of multiple fastqs (lanes, typically)
+	nshards=1
+	R1=[$PWD/.test/473/473_IGO_12587_1_S132_L003_R1_001.fastq.gz,${PWD}/.test/SRR18369973/SRR18369973_1.fastq.gz]
+	R2=[$PWD/.test/473/473_IGO_12587_1_S132_L003_R2_001.fastq.gz,${PWD}/.test/SRR18369973/SRR18369973_2.fastq.gz]
+	addnconf="dedup_platform=SRA"
+	;;
     medium)
 	nshards=2
 	R1=[${PWD}/.test/SRR21986403/SRR21986403_1.fastq.gz]
@@ -26,7 +33,7 @@ case $rawdataset in
 	addnconf="dedup_platform=SRA"
 	;;
     *)
-	echo -e "unknown dataset; please chose from tiny. Exiting\n"
+	echo -e "unknown dataset; please chose from tiny, small, medium, or multilib. Exiting\n"
 	exit 1
 	;;
 esac
@@ -189,7 +196,7 @@ case $mode in
 	    depths=[1000] \
 	    reps=[1,2] \
 	    $addnconf \
-	    stage=rgi
+	    stage=downsample
 	;;
 
   figs )

--- a/workflow/rules/downsample.smk
+++ b/workflow/rules/downsample.smk
@@ -46,10 +46,35 @@ rule all:
         downsampling_reports,
 
 
-rule downsample_fastq:
+if len(config["R1"]) == 1:
+    ds_input_R1 = config["R1"]
+    ds_input_R2 = config["R2"]
+else:
+    ds_input_R1 = "concatenated/{sample}_R1.fastq.gz"
+    ds_input_R2 = "concatenated/{sample}_R2.fastq.gz"
+
+module utils:
+    snakefile:
+        "utils.smk"
+    config:
+        config
+
+
+use rule concat_R1_R2 from utils as utils_concat_R1_R2 with:
     input:
         R1=config["R1"],
         R2=config["R2"],
+    output:
+        R1=temp("concatenated/{sample}_R1.fastq.gz"),
+        R2=temp("concatenated/{sample}_R2.fastq.gz"),
+    log:
+        e="logs/concat_r1_r2_{sample}.e",
+
+
+rule downsample_fastq:
+    input:
+        R1=ds_input_R1,
+        R2=ds_input_R2,
     output:
         R1="ds{depth}_rep{rep}/ds{depth}_rep{rep}_{sample}_R1_001.fastq.gz",
         R2="ds{depth}_rep{rep}/ds{depth}_rep{rep}_{sample}_R2_001.fastq.gz",

--- a/workflow/rules/kraken.smk
+++ b/workflow/rules/kraken.smk
@@ -56,10 +56,15 @@ rule all:
         kraken_unclassified_outputs,
         brackenreport,
 
-
 #
 # Utils Module
-#
+if len(config["R1"]) == 1:
+    input_R1 = config["R1"]
+    input_R2 = config["R2"]
+else:
+    input_R1 = "concatenated/{sample}_R1.fastq.gz"
+    input_R2 = "concatenated/{sample}_R2.fastq.gz"
+
 module utils:
     snakefile:
         "utils.smk"
@@ -100,8 +105,8 @@ rule kraken_standard_run:
     do get are high quality and representative
     """
     input:
-        R1="concatenated/{sample}_R1.fastq.gz",
-        R2="concatenated/{sample}_R2.fastq.gz",
+        R1=input_R1,
+        R2=input_R2,
         db=config["kraken2_db"],
     output:
         out="kraken2/{sample}_kraken2.out",

--- a/workflow/rules/preprocess.smk
+++ b/workflow/rules/preprocess.smk
@@ -61,7 +61,10 @@ rule all:
         host_R1=f"host/{config['sample']}_all_host_reads_R1.fastq.gz",
         host_R2=f"host/{config['sample']}_all_host_reads_R2.fastq.gz",
 
-
+# note:  we could make the concatenation conditional on how many libraries we
+# have, but a nice side-effect of creating a temporary file is that the
+# resulting filename is uniform.  For tools like fastqc, this means we can
+# predict the outputs much easier
 module utils:
     snakefile:
         "utils.smk"


### PR DESCRIPTION
This adds better support for multiple fastqs 
- adds a test "dataset" called multilib
- allows the downsampling app to process multiple fastqs
- allows the kraken app to process multiple fastqs