### PR TITLE
Fix/predetermine annotation assembly chunks

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -18,3 +18,8 @@ from common import *
 # TODO: many of the snakemake input/param functions rely on accessing `config`
 # from the global namespace. That won't work defining that globally in this
 # test module because the imported modules have a different namespace.
+
+def test_make_assembly_split_names():
+    split_names = make_assembly_split_names(10000)
+    assert len(str(split_names[0])) == 3, "bad padding!"
+    assert len(str(split_names[1001])) == 4, "bad padding!"

--- a/workflow/rules/annotate.smk
+++ b/workflow/rules/annotate.smk
@@ -4,7 +4,9 @@ from shutil import rmtree
 import glob
 from math import ceil
 
+
 include: "common.smk"
+
 
 configfile: os.path.join(workflow.basedir, "../../config/config.yaml")
 
@@ -51,10 +53,11 @@ ncontigs = 0
 with open(config["assembly"], "r") as inf:
     for line in inf:
         if line.startswith(">"):
-            ncontigs = ncontigs  + 1
-nparts = ceil(ncontigs/nseqs)
+            ncontigs = ncontigs + 1
+nparts = ceil(ncontigs / nseqs)
 logger.info(f"Breaking assembly into {nparts} {nseqs}-contig chunks")
 BATCHES = [f"stdin.part_{x}" for x in make_assembly_split_names(nparts)]
+
 
 rule all:
     input:
@@ -106,7 +109,7 @@ rule antismash:
         runtime=3 * 60,
     threads: 16
     log:
-        o = "logs/antismash_{sample}.log",
+        o="logs/antismash_{sample}.log",
     output:
         gbk="{sample}_antismash.gbk",
         outdir=directory("antismash_{sample}"),
@@ -178,7 +181,7 @@ rule split_assembly:
         assembly=config["assembly"],
     output:
         directory("tmp"),
-        chunks = expand("tmp/{batch}.fasta", batch=BATCHES),
+        chunks=expand("tmp/{batch}.fasta", batch=BATCHES),
         assembly=temp("tmp-" + os.path.basename(config["assembly"])),
     params:
         outdir="tmp/",
@@ -259,7 +262,7 @@ def aggregate_metaerg_results(wildcards):
 
 rule join_CAZI:
     input:
-        input = expand("cazi_db_scan/{batch}/overview.txt", batch=BATCHES),
+        input=expand("cazi_db_scan/{batch}/overview.txt", batch=BATCHES),
     output:
         f"{config['sample']}_cazi_overview.txt",
     shell:
@@ -275,7 +278,10 @@ rule join_CAZI:
 
 rule join_gffs:
     input:
-        gff = expand("annotation/annotation_{batch}/data/either_all_or_master.gff", batch=BATCHES),
+        gff=expand(
+            "annotation/annotation_{batch}/data/either_all_or_master.gff",
+            batch=BATCHES,
+        ),
     output:
         f"{config['sample']}_metaerg.gff",
     shell:

--- a/workflow/rules/annotate.smk
+++ b/workflow/rules/annotate.smk
@@ -53,7 +53,7 @@ with open(config["assembly"], "r") as inf:
         if line.startswith(">"):
             ncontigs = ncontigs  + 1
 nparts = ceil(ncontigs/nseqs)
-print(f"Breaking assembly into {nparts} {nseqs}-contig chunks")
+logger.info(f"Breaking assembly into {nparts} {nseqs}-contig chunks")
 BATCHES = [f"stdin.part_{x}" for x in make_assembly_split_names(nparts)]
 
 rule all:
@@ -105,14 +105,17 @@ rule antismash:
         mem_mb=16 * 1024,
         runtime=3 * 60,
     threads: 16
+    log:
+        o = "logs/antismash_{sample}.log",
     output:
         gbk="{sample}_antismash.gbk",
+        outdir=directory("antismash_{sample}"),
     shell:
         """
         set +e -x
         antismash --cpus {threads} --allow-long-headers \
             --output-dir antismash_{wildcards.sample} {input.assembly} \
-            --genefinding-gff {input.gff}
+            --genefinding-gff {input.gff} --verbose --logfile {log.o}
         exitcode=$?
         if [ ! $exitcode -eq 0 ]
         then

--- a/workflow/rules/annotate.smk
+++ b/workflow/rules/annotate.smk
@@ -70,7 +70,7 @@ rule annotate_orfs:
         gff="annotation/annotation_{batch}/data/either_all_or_master.gff",
     resources:
         mem_mb=8 * 1024,
-        runtime=2 * 60,
+        runtime=45,
     threads: 4
     params:
         metaerg_db_dir=config["metaerg_db_dir"],

--- a/workflow/rules/annotate.smk
+++ b/workflow/rules/annotate.smk
@@ -290,11 +290,12 @@ rule join_gffs:
 
 
 rule clean_up:
-    """"{sample}_metaerg.gff" is used as an input to ensure
-    that step is done before we clean.
+    """"{sample}_metaerg.gff"  and the cazi merged output is used as an input to ensure
+    this is done last.
     """
     input:
         agg_file="{sample}_metaerg.gff",
+        cazi=f"{config['sample']}_cazi_overview.txt",
     output:
         touch("{sample}.cleaned_dirs"),
     shell:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -12,6 +12,7 @@ def get_pipeline_version():
 def make_shard_names(nshards):
     return [f"{x:03}" for x in range(1, config["nshards"] + 1)]
 
+
 def make_assembly_split_names(nparts):
     split_names = []
     # deal with the 3 digit ones first
@@ -19,10 +20,9 @@ def make_assembly_split_names(nparts):
         split_names.append(f"{i:03}")
     # values after 99 are not padded
     if nparts > 99:
-        for i in range(100, nparts+1):
+        for i in range(100, nparts + 1):
             split_names.append(f"{i}")
-    return(split_names)
-
+    return split_names
 
 
 def files_to_split(wildcards, dedup=False, read_dir=1):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -12,6 +12,18 @@ def get_pipeline_version():
 def make_shard_names(nshards):
     return [f"{x:03}" for x in range(1, config["nshards"] + 1)]
 
+def make_assembly_split_names(nparts):
+    split_names = []
+    # deal with the 3 digit ones first
+    for i in range(1, min(nparts, 100)):
+        split_names.append(f"{i:03}")
+    # values after 99 are not padded
+    if nparts > 99:
+        for i in range(100, nparts+1):
+            split_names.append(f"{i}")
+    return(split_names)
+
+
 
 def files_to_split(wildcards, dedup=False, read_dir=1):
     if dedup:

--- a/workflow/scripts/parse_antismash_gbk.py
+++ b/workflow/scripts/parse_antismash_gbk.py
@@ -7,7 +7,12 @@ from functools import partial
 
 clusters = []
 
-infile = snakemake.input.gbk #infile = sys.argv[1]
+try:
+    infile = snakemake.input.gbk #infile = sys.argv[1]
+    outfile = snakemake.output.tab
+except NameError:
+    infile = sys.argv[1]
+    outfile = sys.argv[2]
 
 open_fun = partial(gzip.open, mode='rt') if  infile.endswith(".gz") else open
 
@@ -28,7 +33,7 @@ with open_fun(infile) as inf:
                 if "product" in seqFeature.qualifiers:
                     clusters[-1]['gctype'] = seqFeature.qualifiers['product'][0]
 
-with open (snakemake.output.tab, "w") as outf:
+with open (outfile, "w") as outf:
     for clus in clusters:
         outf.write("\t".join([str(x) for x in [
             os.path.basename(infile),


### PR DESCRIPTION
To address issue 58 and the difficulty of debugging checkpointed rules, I added a precalculation step so we know how many ncontig chunks the assembly is getting split into, rather then doing it on the fly.  

I also decreased the wall-time for the metaerg runs, and captured the antismash logs