### PR TITLE
incorporate phanta into kraken stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## **Important Notes**:
 
-- Set the location of your profile to the environment variable `$SNAKEPROFILE` (eg `export SNAKEPROFILE=/path/to/your/profile/`)
+- Set the location of your profile to the environment variable `$SNAKEMAKE_PROFILE` (eg `export SNAKEMAKE_PROFILE=/path/to/your/profile/`)
 - For the purposes of the examples, we added the `--dry-run` flag for the user to preview the rules to be executed.  Remove this step to execute the commands.
 - All database paths are configured in `config/config.yaml`  Change the paths to reflect where the databases can be found on your machine.  For a uniform way to fetch and build all the databases, see https://github.com/vdblab/resources
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -30,6 +30,17 @@ blast_16s_db_nsq: "/data/brinkvd/resources/dbs/ncbi16S/2022/16S_ribosomal_RNA.ns
 
 ## Kraken2
 kraken2_db: "/data/brinkvd/resources/dbs/kraken/k2_pluspf_20220908/"
+phanta_unmasked_db: "/data/brinkvd/resources/dbs/kraken/phanta_v1/unmasked_db_v1/"
+phanta_masked_db: "/data/brinkvd/resources/dbs/kraken/phanta_v1_masked/masked_db_v1/"
+skip_phanta: false
+cov_thresh_viral: .1
+cov_thresh_bacterial: .01
+minimizer_thresh_viral: 0
+minimizer_thresh_bacterial: 0
+cov_thresh_arc: 0.01
+minimizer_thresh_arc: 0
+cov_thresh_euk: 0
+minimizer_thresh_euk: 0
 
 ## kaiju
 kaiju_nodes: "/data/brinkvd/resources/kaiju/nodes.dmp"
@@ -88,6 +99,7 @@ docker_megahit: "docker://ghcr.io/vdblab/megahit:5f329c6d24a1480b75145a4c14567a2
 docker_metaerg: "docker://ghcr.io/vdblab/metaerg:1.2.3d"
 docker_metawrap: "docker://ghcr.io/vdblab/metawrap:1.3"
 docker_optitype: "docker://fred2/optitype"
+docker_phanta: "docker://ghcr.io/vdblab/phanta:1.1.0"
 docker_rgi: "docker://ghcr.io/vdblab/rgi:6.0.0"
 docker_seqkit: "docker://ghcr.io/vdblab/seqkit:2.3.1"
 docker_snap: "docker://ghcr.io/vdblab/snap-aligner:2.0.1"

--- a/test.sh
+++ b/test.sh
@@ -132,7 +132,7 @@ case $mode in
 	snakemake \
 	    $common_args \
 	    --singularity-args "-B ${PWD},/data/brinkvd/" \
-	    --directory tmpkraken/ \
+            --directory tmpkraken_${rawdataset}/ \
 	    --config \
 	    sample=473  \
 	    R1=$R1 \

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -15,6 +15,7 @@ configfile: os.path.join(workflow.basedir, "../config/config.yaml")
 
 envvars:
     "TMPDIR",
+    "SNAKEMAKE_PROFILE",
 
 
 validate(

--- a/workflow/rules/kraken.smk
+++ b/workflow/rules/kraken.smk
@@ -361,7 +361,6 @@ rule phanta:
         total_reads="phanta_{sample}/{db}/results/final_merged_outputs/total_reads.tsv",
     container:
         config["docker_phanta"]
-    # handover: True
     params:
         dbpath=lambda wc: config[wc.db],
         sing_args=lambda wc: get_singularity_args(wc),

--- a/workflow/rules/kraken.smk
+++ b/workflow/rules/kraken.smk
@@ -6,7 +6,6 @@ import shutil
 from pathlib import Path
 from snakemake.utils import validate
 
-
 include: "common.smk"
 
 
@@ -18,10 +17,10 @@ validate(config, os.path.join(str(workflow.basedir), "../../config/config.schema
 
 envvars:
     "TMPDIR",
+    "SNAKEMAKE_PROFILE",
 
 
 SHARDS = make_shard_names(config["nshards"])
-
 
 onstart:
     with open("config_used.yaml", "w") as outfile:
@@ -48,13 +47,25 @@ brackenreport = expand(
 krona = expand(
     "reports/{sample}_kraken2.bracken.S.report.krona.html", sample=config["sample"]
 )
+phanta_db_names = ["phanta_unmasked_db", "phanta_masked_db"]
+phanta_outputs = expand(f'phanta_{config["sample"]}/{{db}}/results/final_merged_outputs/counts.txt',
+                        db=phanta_db_names)
 
+phanta_extra_outputs = expand(f'phanta_{config["sample"]}/{{db}}/results/counts_by_host.tsv',
+                              db=phanta_db_names)
+
+all_outputs= [
+    kraken_outputs,
+    kraken_unclassified_outputs,
+    brackenreport
+]
+if not config['skip_phanta']:
+    all_outputs.extend(phanta_outputs)
+    all_outputs.extend(phanta_extra_outputs)
 
 rule all:
     input:
-        kraken_outputs,
-        kraken_unclassified_outputs,
-        brackenreport,
+        all_outputs
 
 
 #
@@ -311,4 +322,111 @@ rule kraken_merge_shards:
             -r {input.reports} \
             -o {output.out} \
             > {log.o} 2> {log.e}
+        """
+
+rule make_phanta_manifest:
+    input:
+        R1=input_R1,
+        R2=input_R2,
+    output:
+        manifest= temp('phanta_inputs.tsv'),
+    params:
+        sample=config["sample"],
+    shell: """echo -e "{params.sample}\t{input.R1}\t{input.R2}" > {output.manifest}"""
+
+
+def get_singularity_args(wildcards):
+    with open(os.path.join(os.environ["SNAKEMAKE_PROFILE"], "config.yaml"), 'r') as f:
+        return yaml.safe_load(f)["singularity-args"]
+
+rule phanta:
+    # we need the results dir because if we try to initiate two snakemake workflows from the same --directory we get LockErrors
+    input:
+        R1=input_R1,
+        R2=input_R2,
+        manifest=rules.make_phanta_manifest.output.manifest,
+        readlen_file=parse_read_lengths,
+    output:
+        counts= 'phanta_{sample}/{db}/results/final_merged_outputs/counts.txt',
+        bracken_failed= 'phanta_{sample}/{db}/results/classification/samples_that_failed_bracken.txt',
+        bracken_report= 'phanta_{sample}/{db}/results/classification/{sample}.krak.report_bracken_species.filtered',
+        bracken_species_abundance= 'phanta_{sample}/{db}/results/classification/{sample}.krak.report.filtered.bracken.scaled',
+        relative_read_abundance= 'phanta_{sample}/{db}/results/final_merged_outputs/relative_read_abundance.txt',
+        relative_taxonomic_abundance= 'phanta_{sample}/{db}/results/final_merged_outputs/relative_taxonomic_abundance.txt',
+        total_reads= 'phanta_{sample}/{db}/results/final_merged_outputs/total_reads.tsv',
+    container: config["docker_phanta"]
+    #handover: True
+    params:
+        dbpath = lambda wc: config[wc.db],
+        sing_args = lambda wc: get_singularity_args(wc),
+        cov_thresh_viral=config['cov_thresh_viral'],
+        cov_thresh_arc=config['cov_thresh_arc'],
+        cov_thresh_bacterial=config['cov_thresh_bacterial'],
+        cov_thresh_euk=config['cov_thresh_euk'],
+        minimizer_thresh_viral=config['minimizer_thresh_viral'],
+        minimizer_thresh_arc=config['minimizer_thresh_arc'],
+        minimizer_thresh_bacterial=config['minimizer_thresh_bacterial'],
+        minimizer_thresh_euk=config['minimizer_thresh_euk'],
+    resources:
+        mem_mb=lambda wildcards, attempt: 58 * 1024 * attempt
+    threads: 16
+    # we have to do the dummy profile to keep the job from inheiriting SNAKEMAKE_PROFILE;
+    #   we want this job to be submitted locally.  Otherwise, we have this unpleasant
+    # situation where we need the docker container for its snakefile, but also
+    # need the workflow itself to execute within the same container.  Cue mount point conflicts,
+    # the inability to test, etc.
+    # The workaround is running it without a --cluster directive so it runs 'locally',
+    # which is actually on the node this rule got submitted to. While there is a slight
+    # inefficiency, phanta doesn't benefit enough from distributing its workflow rules to
+    # warrant going the alternative route of adding it to this repo as a submodule,
+    # importing the rules, etc.
+    shell:
+        """
+        READLEN=$(basename {input.readlen_file} | sed 's|len||' | sed  's|approx||')
+        echo "cores: {threads}" > config.yaml && \
+        snakemake  --profile $PWD --notemp \
+        --singularity-args '{params.sing_args}' \
+        --snakefile /home/mambauser/phanta/Snakefile \
+        --configfile /home/mambauser/phanta/config.yaml \
+        --directory phanta_{wildcards.sample}/{wildcards.db}/ \
+        --config \
+        outdir="results/" \
+        read_length=$READLEN \
+        cov_thresh_viral={params.cov_thresh_viral} \
+        cov_thresh_bacterial={params.cov_thresh_bacterial} \
+        cov_thresh_euk={params.cov_thresh_euk} \
+        cov_thresh_arc={params.cov_thresh_arc} \
+        minimizer_thresh_viral={params.minimizer_thresh_viral} \
+        minimizer_thresh_bacterial={params.minimizer_thresh_bacterial} \
+        minimizer_thresh_euk={params.minimizer_thresh_euk} \
+        minimizer_thresh_arc={params.minimizer_thresh_arc} \
+        class_mem_mb={resources.mem_mb} \
+        database={params.dbpath} \
+        pipeline_directory=/home/mambauser/phanta/ \
+        sample_file=$PWD/{input.manifest}
+        """
+
+rule phanta_postprocess:
+    input:
+        counts= 'phanta_{sample}/{db}/results/final_merged_outputs/counts.txt',
+        tax_relab='phanta_{sample}/{db}/results/final_merged_outputs/relative_taxonomic_abundance.txt',
+    output:
+        byhost= 'phanta_{sample}/{db}/results/counts_by_host.tsv',
+        lifestyle= 'phanta_{sample}/{db}/results/lifestype_stats.txt',
+    container:
+        config["docker_phanta"]
+    params:
+        dbpath = lambda wc: config[wc.db],
+        bacphlip_thresh = .5,
+    resources:
+        mem_mb= 8 * 1024
+    threads: 1
+    shell:
+        """
+        python   /home/mambauser/phanta/post_pipeline_scripts/collapse_viral_abundances_by_host.py {input.counts}  {params.dbpath}/host_prediction_to_genus.tsv  {output.byhost}
+        Rscript /home/mambauser/phanta/post_pipeline_scripts/calculate_lifestyle_stats/lifestyle_stats.R \
+          {params.bacphlip_thresh} {params.dbpath}/species_name_to_vir_score.txt \
+          {input.counts} \
+          {input.tax_relab} \
+          {output.lifestyle}
         """

--- a/workflow/rules/kraken.smk
+++ b/workflow/rules/kraken.smk
@@ -76,8 +76,8 @@ if len(config["R1"]) == 1:
     input_R1 = config["R1"]
     input_R2 = config["R2"]
 else:
-    input_R1 = "concatenated/{sample}_R1.fastq.gz"
-    input_R2 = "concatenated/{sample}_R2.fastq.gz"
+    input_R1 = f"concatenated/{config['sample']}_R1.fastq.gz"
+    input_R2 = f"concatenated/{config['sample']}_R2.fastq.gz"
 
 
 module utils:


### PR DESCRIPTION
Since we want to run PHANTA on both the masked and unmasked databases, as well as the post processing scripts, I have incorporated it into the kraken module.  There are a few little quirks to note:

### Snakemake within snakemake
The two main problems I was attempting to overcome are how do we use phanta and how do we ensure phanta has the dependencies it needs.

For getting phanta, the three options I saw were via git submodule, snakemake remote, or bundling it into a docker container.  Since we already containerize our rule dependencies, I decided to go with docker.  

In order to avoid dealing with conda environments, I made the docker container with all the dependencies conveniently described by the conda env in the phanta repo. 

However, when I tried running this, I ran into the issue that jobs spawned from this rule were not being run from the same container. To address this, I then added a self-referential `containerize` directive to the main Snakefile; see 
https://github.com/vdblab/dockerfiles/blob/967ed8d70d328a726c573c92bb50b3ae33a8c926/phanta/Dockerfile#L11.  I tried avoiding this using the `handover` directive, and but using the `--container`  cli arg, but neither worked.

I ended up having this rule run as a "local" job (that is, local to the node the phanta rules are distibuted to, as opposed to those nodes then acting as the head node sending rules to other nodes).  The main issue was conflcting mount points when running a containerized workflow from a containerized environment.  Because of this, it might be the above `containerize` is not necessary.

### This PR
Ive added 8 relevant arguments from phanta to our config, as well as a `skip_phanta` option we can enable for testing.  The workflow runs phanta twice: once for the masked database, and once for the unmasked.  Two of the downstream scripts have been added as well to predict lifestyle and host-specificity.  I did not do the correlation analysis script as that involves running kraken individually for each read direction, which adds runtime/space overhead.  But, we could decide to do that in the future.

I also changed the Snakemake profile variable from SNAKEPROFILE to SNAKEMAKE_PROFILE, which snakemake will look for automatically!



