### PR TITLE
Change submodule validates

### DIFF
--- a/workflow/rules/HLA.smk
+++ b/workflow/rules/HLA.smk
@@ -1,14 +1,10 @@
 import os
 from snakemake.remote.HTTP import RemoteProvider as HTTPRemoteProvider
-from snakemake.utils import validate
 
 HTTP = HTTPRemoteProvider()
 
 
 configfile: os.path.join(str(workflow.current_basedir), "../../config/config.yaml")
-
-
-validate(config, os.path.join(str(workflow.basedir), "../../config/config.schema.yaml"))
 
 
 rule all:

--- a/workflow/rules/assembly.smk
+++ b/workflow/rules/assembly.smk
@@ -38,15 +38,22 @@ onstart:
         os.makedirs("logs")
     if config["assembler"].lower() == "spades":
         if len(config["R1"]) > 1:
-            print("WARNING: Concatenating multiple inputs into a single paired library as metaspades does not support multiple libraries")
+            print(
+                "WARNING: Concatenating multiple inputs into a single paired library as metaspades does not support multiple libraries"
+            )
         print("Running SPAdes")
     else:
         print("Running megahit")
 
 
 if config["assembler"].lower() == "spades":
-    assemblies = [f"spades_{config['sample']}.assembly.fasta", f"spades_{config['sample']}_metaviral/scaffolds.fasta"]
-    assemblies_labels = ",".join([f"metaspades_{config['sample']}",f"metaviralspades_{config['sample']}"])
+    assemblies = [
+        f"spades_{config['sample']}.assembly.fasta",
+        f"spades_{config['sample']}_metaviral/scaffolds.fasta",
+    ]
+    assemblies_labels = ",".join(
+        [f"metaspades_{config['sample']}", f"metaviralspades_{config['sample']}"]
+    )
     all_inputs.append(f"{config['sample']}.cleaned_assembly_files")
     all_inputs.extend(assemblies)
 # elif config["assembler"].lower() == "both": # should this be enabled?
@@ -93,6 +100,7 @@ use rule concat_R1_R2 from utils as utils_concat_R1_R2 with:
         R2=temp("concatenated/{sample}_R2.fastq.gz"),
     log:
         e="logs/concat_r1_r2_{sample}.e",
+
 
 rule megahit:
     input:
@@ -155,6 +163,7 @@ rule SPAdes_run:
         mv spades_{wildcards.sample}/assembly_graph_with_scaffolds.gfa {output.graph}
         """
 
+
 rule viral_SPAdes_run:
     # max_kmer https://github.com/ablab/spades/discussions/1188
     # --onlyassembler seems to be neccessary when using assembly graph input
@@ -168,7 +177,7 @@ rule viral_SPAdes_run:
     container:
         config["docker_spades"]
     params:
-        max_kmer=55
+        max_kmer=55,
     conda:
         "../envs/spades.yaml"
     resources:

--- a/workflow/rules/assembly.smk
+++ b/workflow/rules/assembly.smk
@@ -4,16 +4,12 @@ import yaml
 import shutil
 
 from pathlib import Path
-from snakemake.utils import validate
 
 
 include: "common.smk"
 
 
 configfile: os.path.join(str(workflow.basedir), "../../config/config.yaml")
-
-
-validate(config, os.path.join(str(workflow.basedir), "../../config/config.schema.yaml"))
 
 
 envvars:

--- a/workflow/rules/binning.smk
+++ b/workflow/rules/binning.smk
@@ -4,7 +4,6 @@ import yaml
 import shutil
 
 from pathlib import Path
-from snakemake.utils import validate
 
 
 include: "common.smk"
@@ -12,12 +11,6 @@ include: "common.smk"
 
 # the str is needed as when running from github workflow.current_basedir is a Githubfile, not a string or a path so os.path objects
 configfile: os.path.join(str(workflow.current_basedir), "../../config/config.yaml")
-
-
-validate(
-    config,
-    os.path.join(str(workflow.current_basedir), "../../config/config.schema.yaml"),
-)
 
 
 envvars:

--- a/workflow/rules/binning.smk
+++ b/workflow/rules/binning.smk
@@ -159,10 +159,17 @@ rule coverm:
         stats=f'metawrap/refined_binning_{{sample}}/metawrap_{config["metawrap_compl_thresh"]}_{config["metawrap_contam_thresh"]}_bins.stats',
     output:
         mqc=f'coverm/{{sample}}_metawrap_{config["metawrap_compl_thresh"]}_{config["metawrap_contam_thresh"]}_bins.coverage_mqc.tsv',
-        bams=directory(f'coverm/{{sample}}_metawrap_{config["metawrap_compl_thresh"]}_{config["metawrap_contam_thresh"]}_bams/'),
+        bams=directory(
+            f'coverm/{{sample}}_metawrap_{config["metawrap_compl_thresh"]}_{config["metawrap_contam_thresh"]}_bams/'
+        ),
     params:
         bindir=lambda wc, input: input.stats.replace(".stats", ""),
-        fastq_string = lambda wc, input: " ".join([config["R1"][x] + " " + config["R2"][x] for x in range(0, len(config["R1"]))])
+        fastq_string=lambda wc, input: " ".join(
+            [
+                config["R1"][x] + " " + config["R2"][x]
+                for x in range(0, len(config["R1"]))
+            ]
+        ),
     container:
         config["docker_coverm"]
     threads: 16

--- a/workflow/rules/biobakery.smk
+++ b/workflow/rules/biobakery.smk
@@ -5,6 +5,7 @@ import shutil
 
 from pathlib import Path
 
+
 include: "common.smk"
 
 

--- a/workflow/rules/biobakery.smk
+++ b/workflow/rules/biobakery.smk
@@ -4,16 +4,11 @@ import yaml
 import shutil
 
 from pathlib import Path
-from snakemake.utils import validate
-
 
 include: "common.smk"
 
 
 configfile: os.path.join(str(workflow.basedir), "../../config/config.yaml")
-
-
-validate(config, os.path.join(str(workflow.basedir), "../../config/config.schema.yaml"))
 
 
 envvars:

--- a/workflow/rules/bowtie2.smk
+++ b/workflow/rules/bowtie2.smk
@@ -4,7 +4,6 @@ import yaml
 import shutil
 
 from pathlib import Path
-from snakemake.utils import validate
 
 
 include: "common.smk"

--- a/workflow/rules/classify_bins.smk
+++ b/workflow/rules/classify_bins.smk
@@ -14,7 +14,6 @@ include: "common.smk"
 configfile: os.path.join(str(workflow.current_basedir), "../../config/config.yaml")
 
 
-
 envvars:
     "TMPDIR",
 
@@ -22,7 +21,10 @@ envvars:
 SHARDS = make_shard_names(config["nshards"])
 MAGs = glob.glob(os.path.join(config["bindir"] + "*.fa"))
 if not MAGs:
-    raise ValueError(f'No MAGs found with pattern {os.path.join(config["bindir"] + "*.fa")}')
+    raise ValueError(
+        f'No MAGs found with pattern {os.path.join(config["bindir"] + "*.fa")}'
+    )
+
 
 onstart:
     with open("config_used.yaml", "w") as outfile:
@@ -36,12 +38,11 @@ localrules:
     all,
 
 
-
-
 rule all:
     input:
         f"gtdbtk-{config['sample']}/gtdbtk.json",
-        f"kraken2/{config['sample']}_kraken2.report"
+        f"kraken2/{config['sample']}_kraken2.report",
+
 
 rule gtdb_classify:
     """ Cant have the tabular output because if a sample lacks bacteria or archaea it will omit that domains output file
@@ -49,21 +50,22 @@ rule gtdb_classify:
     input:
         bindir=config["bindir"],
     output:
-        "gtdbtk-{sample}/gtdbtk.json"
+        "gtdbtk-{sample}/gtdbtk.json",
     container:
         config["docker_gtdbtk"]
     params:
         db=config["gtdb_db"],
-        outdir=lambda wc, output: os.path.dirname(output[0])
+        outdir=lambda wc, output: os.path.dirname(output[0]),
     threads: 32
     resources:
         # ~64 is recommended by their docs
-        mem_mb=68*1024
+        mem_mb=68 * 1024,
     shell:
         """
         export GTDBTK_DATA_PATH={params.db}
         gtdbtk classify_wf --genome_dir {input.bindir} --cpus {threads} -x fa --out_dir {params.outdir} --mash_db {params.db}/mash
         """
+
 
 module kraken:
     snakefile:
@@ -73,6 +75,7 @@ module kraken:
     skip_validation:
         True
 
+
 use rule kraken_standard_run from kraken with:
     input:
         R1=MAGs,
@@ -81,4 +84,4 @@ use rule kraken_standard_run from kraken with:
         out="kraken2/{sample}_kraken2.out",
         unclass_R1=temp("kraken2/{sample}_kraken2_unclassified_1.fastq"),
         unclass_R2=temp("kraken2/{sample}_kraken2_unclassified_2.fastq"),
-        report="kraken2/{sample}_kraken2.report"
+        report="kraken2/{sample}_kraken2.report",

--- a/workflow/rules/classify_bins.smk
+++ b/workflow/rules/classify_bins.smk
@@ -5,7 +5,6 @@ import yaml
 import shutil
 
 from pathlib import Path
-from snakemake.utils import validate
 
 
 include: "common.smk"
@@ -14,11 +13,6 @@ include: "common.smk"
 # the str is needed as when running from github workflow.current_basedir is a Githubfile, not a string or a path so os.path objects
 configfile: os.path.join(str(workflow.current_basedir), "../../config/config.yaml")
 
-
-validate(
-    config,
-    os.path.join(str(workflow.current_basedir), "../../config/config.schema.yaml"),
-)
 
 
 envvars:

--- a/workflow/rules/hostdeplete.smk
+++ b/workflow/rules/hostdeplete.smk
@@ -12,7 +12,6 @@ include: "common.smk"
 configfile: os.path.join(str(workflow.current_basedir), "../../config/config.yaml")
 
 
-
 onstart:
     with open("config_used.yaml", "w") as outfile:
         yaml.dump(config, outfile)

--- a/workflow/rules/hostdeplete.smk
+++ b/workflow/rules/hostdeplete.smk
@@ -4,7 +4,6 @@ import yaml
 import shutil
 
 from pathlib import Path
-from snakemake.utils import validate
 
 
 include: "common.smk"
@@ -12,11 +11,6 @@ include: "common.smk"
 
 configfile: os.path.join(str(workflow.current_basedir), "../../config/config.yaml")
 
-
-validate(
-    config,
-    os.path.join(str(workflow.current_basedir), "../../config/config.schema.yaml"),
-)
 
 
 onstart:

--- a/workflow/rules/kraken.smk
+++ b/workflow/rules/kraken.smk
@@ -5,6 +5,7 @@ import shutil
 
 from pathlib import Path
 
+
 include: "common.smk"
 
 
@@ -130,7 +131,9 @@ rule kraken_standard_run:
         unclass_R2=temp("kraken2/{sample}_kraken2_unclassified_2.fastq"),
         report="kraken2/{sample}_kraken2.report",
     params:
-        inpstr=lambda wc, input: f"--paired {input.R1} {input.R2}" if hasattr(input, "R2")  else input.R1,
+        inpstr=lambda wc, input: (
+            f"--paired {input.R1} {input.R2}" if hasattr(input, "R2") else input.R1
+        ),
         unclass_template=lambda wildcards, output: output["unclass_R1"].replace(
             "_1.fastq", "#.fastq"
         ),
@@ -142,9 +145,9 @@ rule kraken_standard_run:
         e="logs/kraken_{sample}.log",
     resources:
         # use 8GB mem if using a minikraken db to make testing easier
-        mem_mb=lambda wildcards, attempt: 8 * 1024
-        if "mini" in config["kraken2_db"]
-        else (64 * 1024 * attempt),
+        mem_mb=lambda wildcards, attempt: (
+            8 * 1024 if "mini" in config["kraken2_db"] else (64 * 1024 * attempt)
+        ),
     threads: 16
     shell:
         """

--- a/workflow/rules/kraken.smk
+++ b/workflow/rules/kraken.smk
@@ -4,16 +4,11 @@ import yaml
 import shutil
 
 from pathlib import Path
-from snakemake.utils import validate
-
 
 include: "common.smk"
 
 
 configfile: os.path.join(str(workflow.basedir), "../../config/config.yaml")
-
-
-validate(config, os.path.join(str(workflow.basedir), "../../config/config.schema.yaml"))
 
 
 envvars:

--- a/workflow/rules/preprocess.smk
+++ b/workflow/rules/preprocess.smk
@@ -4,7 +4,6 @@ import yaml
 import shutil
 
 from pathlib import Path
-from snakemake.utils import validate
 
 
 include: "common.smk"
@@ -16,11 +15,6 @@ configfile: os.path.join(str(workflow.basedir), "../../config/config.yaml")
 envvars:
     "TMPDIR",
 
-
-validate(
-    config,
-    os.path.join(str(workflow.current_basedir), "../../config/config.schema.yaml"),
-)
 
 SHARDS = make_shard_names(config["nshards"])
 TMPDIR = Path(os.environ["TMPDIR"])

--- a/workflow/rules/spikedepletion.smk
+++ b/workflow/rules/spikedepletion.smk
@@ -4,8 +4,6 @@ import yaml
 import shutil
 
 from pathlib import Path
-from snakemake.utils import validate
-
 
 include: "common.smk"
 
@@ -13,11 +11,6 @@ include: "common.smk"
 # the str is needed as when running from github workflow.current_basedir is a Githubfile, not a string or a path so os.path objects
 configfile: os.path.join(str(workflow.current_basedir), "../../config/config.yaml")
 
-
-# validate(
-#     config,
-#     os.path.join(str(workflow.current_basedir), "../../config/config.schema.yaml"),
-# )
 
 
 envvars:


### PR DESCRIPTION
I have been reusing parts from the `vdblab-shotgun` in my new snakemake pipeline using the module import capacity.  Unfortunately one downside of having the validate calls in the individual .smk files is that it enforces all the requirements of the `config.schema.yaml` file from `vdblab-shotgun` onto whatever snakefile is trying to use it!  By removing these valideas and setting skip_validate to True (thanks Nick!) I am able to get around these requirements. 

Personally I really like that these are very modular components, I think that this requirement for validation within these sub components makes them less reusable.  Open to another way to solve this problem as well, for now just putting this here as a means to start the conversation. 

Cheers! 