### PR TITLE
WIP trimming resources

### DIFF
--- a/workflow/rules/biobakery.smk
+++ b/workflow/rules/biobakery.smk
@@ -87,7 +87,7 @@ rule humann3_run_uniref90:
         * 1024
         * max(input.fastq.size // 1000000000, 1)
         * 10,
-        runtime=24 * 60,
+        runtime=lambda wc, attempt: 16 * 60 * attempt,
     threads: 64
     # we have an extra log in case there is an error with humann.  Cause
     # we skip the built in logging because
@@ -264,8 +264,9 @@ rule metaphlan_run:
     conda:
         "../envs/metaphlan.yaml"
     resources:
-        mem_mb=16 * 1024,
-        runtime=20 * 60,
+        # first submission is given 30GB, then 45,
+        mem_mb=lambda wildcards, attempt: (0.5 + (attempt / 2)) * 1024 * 30,
+        runtime=lambda wc, attempt: 2 * 60 * attempt,
     threads: 64
     log:
         e="logs/metaphlan_{sample}.e",

--- a/workflow/rules/biobakery.smk
+++ b/workflow/rules/biobakery.smk
@@ -86,8 +86,9 @@ rule humann3_run_uniref90:
         mem_mb=lambda wildcards, attempt, input: attempt
         * 1024
         * max(input.fastq.size // 1000000000, 1)
-        * 10,
-        runtime=lambda wc, attempt: 16 * 60 * attempt,
+        * 5
+        * attempt,
+        runtime=lambda wc, attempt: 8 * 60 * attempt,
     threads: 64
     # we have an extra log in case there is an error with humann.  Cause
     # we skip the built in logging because
@@ -265,9 +266,9 @@ rule metaphlan_run:
         "../envs/metaphlan.yaml"
     resources:
         # first submission is given 30GB, then 45,
-        mem_mb=lambda wildcards, attempt: (0.5 + (attempt / 2)) * 1024 * 30,
+        mem_mb=lambda wildcards, attempt: 30 * 1024 * attempt,
         runtime=lambda wc, attempt: 2 * 60 * attempt,
-    threads: 64
+    threads: 32
     log:
         e="logs/metaphlan_{sample}.e",
     shell:

--- a/workflow/rules/hostdeplete.smk
+++ b/workflow/rules/hostdeplete.smk
@@ -85,7 +85,10 @@ rule s01_bowtie2:
         input_string=lambda wildcards, input: f"-1 {input.R1} -2 {input.R2}"
         if is_paired()
         else f"-U {input.R1}",
-    threads: 24
+    threads: 16
+    resources:
+        mem_mb=lambda wc, attempt: 12 * 1024 * attempt,
+        runtime=lambda wc, attempt: 1 * 60 * attempt,
     shell:
         """
           (bowtie2 \
@@ -124,10 +127,9 @@ rule s02_snapalign:
         db_prefix=lambda wildcards, input: os.path.dirname(input.idx_genome),
         cmd=config["lib_layout"],
     resources:
-        mem_mb=lambda wildcards, attempt, input: attempt
-        * (max(input.size // 1000000, 1024) * 10),
-        runtime=48 * 60,
-    threads: 24  # Use at least two threads
+        mem_mb=lambda wc, attempt: 10 * 1024 * attempt,
+        runtime=lambda wc, attempt: 1.5 * 60 * attempt,
+    threads: 16  # Use at least two threads
     shell:
         """
         snap-aligner {params.cmd} {params.db_prefix} \

--- a/workflow/rules/preprocess.smk
+++ b/workflow/rules/preprocess.smk
@@ -114,7 +114,6 @@ rule bbmap_dedup:
     output:
         reads=temp(expand("dedup/{{sample}}_R{rd}.fastq.gz", rd=config["readdirs"])),
         dedup_stats="reports/{sample}_dedup.stats",
-    threads: 8
     params:
         allowed_subs=3,
         flags=lambda wc: bbmap_dedup_params_flags(wc, config),
@@ -124,10 +123,11 @@ rule bbmap_dedup:
         outputstring=lambda wc, output: f"out={output.reads[0]} out2={output.reads[1]}"
         if is_paired()
         else f"out={output.reads[0]}",
+    threads: 8
     resources:
         mem_mb=lambda wildcards, input, attempt: attempt
         * (max(input.size // 1000000, 1024) * 16),
-        runtime=24 * 60,
+        runtime=lambda wildcards, attempt:  1 * 60 * attempt,
     log:
         # this is annoying but we want to be able to extract the stats from
         # the logs, which we can't do without the logs as a file. Perhaps
@@ -379,7 +379,7 @@ rule aligned_host_reads_to_fastq:
         aligned_samflags="-f 2 -F 512" if is_paired() else "-F 3844",
     threads: 8
     resources:
-        runtime=8 * 60,
+        runtime=1 * 60,
     container:
         config["docker_bowtie2"]
     shell:
@@ -414,7 +414,7 @@ rule make_combined_host_reads_fastq:
         R1="host/{sample}_all_host_reads_R{readdir}.fastq.gz",
     threads: 8
     resources:
-        runtime=8 * 60,
+        runtime=2 * 60,
     container:
         config["docker_bowtie2"]
     shell:
@@ -441,7 +441,7 @@ rule sortmerna_run:
         if is_paired()
         else f"--reads {input['R1']}",
     resources:
-        mem_mb=16000,
+        mem_mb=16 * 1024,
     threads: 16
     message:
         "Quantify rRNA for qPCR normalization and 16S comparison"

--- a/workflow/rules/preprocess.smk
+++ b/workflow/rules/preprocess.smk
@@ -126,8 +126,8 @@ rule bbmap_dedup:
     threads: 8
     resources:
         mem_mb=lambda wildcards, input, attempt: attempt
-        * (max(input.size // 1000000, 1024) * 16),
-        runtime=lambda wildcards, attempt:  1 * 60 * attempt,
+        * (max(input.size // 1000000, 1024) * 10),
+        runtime=lambda wildcards, attempt: 1 * 60 * attempt * attempt,
     log:
         # this is annoying but we want to be able to extract the stats from
         # the logs, which we can't do without the logs as a file. Perhaps
@@ -441,7 +441,8 @@ rule sortmerna_run:
         if is_paired()
         else f"--reads {input['R1']}",
     resources:
-        mem_mb=16 * 1024,
+        mem_mb=lambda wc, attempt: 6 * 1024 * attempt,
+        runtime=lambda wc, attempt: 2 * attempt * attempt * attempt,
     threads: 16
     message:
         "Quantify rRNA for qPCR normalization and 16S comparison"


### PR DESCRIPTION
Now that we have ~5k samples processed, I wanted to see what our resource utilization looked like to see if there were opportunities for trimming the requested resources.  I focused on the preprocessing and MetaPhlan/Humann workflows for the time being. Here is what I found:

<img width="374" alt="Screen Shot 2024-05-20 at 4 24 44 PM" src="https://github.com/vdblab/vdblab-shotgun/assets/14367274/03c9d8f2-2ba4-4d2a-a596-e8d67f075031">


<img width="374" alt="Screen Shot 2024-05-20 at 4 25 49 PM" src="https://github.com/vdblab/vdblab-shotgun/assets/14367274/4a61ad65-120d-4c90-a1ec-4d3ff8b0a391">
<img width="374" alt="Screen Shot 2024-05-20 at 4 25 29 PM" src="https://github.com/vdblab/vdblab-shotgun/assets/14367274/2b364269-6234-476f-8825-135eb211efec">

## Metaphlan
Metaphlan tends to use ~25GB memory, and complete in less than 30 minutes; the cluster was requesting 1gb per core, so 64GB memory, resulting is a median less than 40% utilization.  Here, I reduced the memory to 30GB, and the runtime to 2hr, and the number of cores 32. Both memory and runtime scale with subsequent attempts.

## Humann
Humann  was similarly underutilizing memory. Most ran in under three hours, but some took upwards of 12. The default was changed to 8, scaling with attempt.  Memory was previously specified as 10gb per combined input gb; as our  was rarely above 50%, I changed the default to 5GB per GB of input, scaling with attempt as well.

## Deduplication with BBMap Clumpify
Memory was previously specified as 16Gb per input GB; utilization appears to be normally less than 60%, so I decreased this to 10GB, scaling with attempt. Runtime rarely exceeds an hour, so I changed the default to that, scaling with attempt squared.

## SortMeRNA
Memory was specified for 16GB, and the median utilization was around 10%.  Updated to 6gb by default, scaling with attempt. Median runtime was under a half hour; I changed the default to 2 hr scaling with the cubed attempt.

## Snap
Similar to humann, snap was given 10GB per input GB. This rule is operated per shard. This resulted in less than 20% utilization.  Memory is related to the reference, so it looks like we can set this to 10GB scaled with attempt. Runtime never exceeded an hour, the default is 90 minutes, scaled with attempt, and I dropped from 24 to 16 threads for (hopefully) faster queueing.

## Bowtie2
Similar to snap, but slightly more memory needed so set to 12GB with scaling by attempt, and starting the runtime at an hour