### PR TITLE
Sharding humann3 translated alignment 

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -12,6 +12,7 @@ retries: 3
 ## bioBakery
 choco_db: "/data/brinkvd/resources/dbs/chocophlan/v201901_v31/"
 uniref90_db: "/data/brinkvd/resources/dbs/uniref90_diamond/v201901b/"
+diamond_db_file: "/data/brinkvd/resources/dbs/uniref90_diamond/v201901b/uniref90_201901b_full.dmnd"
 utility_mapping_db: "/data/brinkvd/resources/dbs/utility_mapping/utility_mapping/"
 metaphlan_db: "/data/brinkvd/resources/dbs/metaphlan/mpa_vJan21_CHOCOPhlAnSGB_202103/"
 skip_sample2markers: false
@@ -101,6 +102,7 @@ docker_bmtagger: "docker://ghcr.io/vdblab/kneaddata-bmtagger:0.6.1"
 docker_coverm: "docker://ghcr.io/vdblab/coverm:0.6.1"
 docker_cutadapt: "docker://ghcr.io/vdblab/cutadapt:3.7"
 docker_dbcan: "docker://ghcr.io/vdblab/dbcan3:4.1.4.12"
+docker_diamond : "docker://pegi3s/diamond:2.1.9"
 docker_fastqc: "docker://staphb/fastqc:0.11.9"
 docker_gtdbtk: "docker://ecogenomic/gtdbtk:2.3.2"
 docker_hla: "docker://humanlongevity/hla:0.0.0"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -16,6 +16,7 @@ diamond_db_file: "/data/brinkvd/resources/dbs/uniref90_diamond/v201901b/uniref90
 utility_mapping_db: "/data/brinkvd/resources/dbs/utility_mapping/utility_mapping/"
 metaphlan_db: "/data/brinkvd/resources/dbs/metaphlan/mpa_vJan21_CHOCOPhlAnSGB_202103/"
 skip_sample2markers: false
+keep_temp_human_files: false
 
 ## CheckM
 checkm_db: "/data/brinkvd/resources/dbs/checkm/2015_01_16/"

--- a/workflow/rules/biobakery.smk
+++ b/workflow/rules/biobakery.smk
@@ -166,7 +166,7 @@ rule humann3_step3_translated_alignment_of_shards:
     container:
         config["docker_diamond"]
     resources:
-        mem_mb=lambda wc, attempt: 1024 * 5 * attempt,
+        mem_mb=lambda wc, attempt: 1024 * (20 + 10 * attempt),
         runtime=lambda wc, attempt: 5 * 60 * attempt,
     threads: 4
     log:

--- a/workflow/rules/hostdeplete.smk
+++ b/workflow/rules/hostdeplete.smk
@@ -74,17 +74,19 @@ rule s01_bowtie2:
         e=f"logs/bowtie2_{{sample}}.{bowtie2_human_db_name}.e",
         o=f"logs/bowtie2_{{sample}}.{bowtie2_human_db_name}.o",
     params:
-        umapped_string=lambda wildcards, output: "--un-conc-gz "
-        + output["unmapped_reads"][0].replace(".R1.fastq.gz", ".R%.fastq.gz")
-        if is_paired()
-        else "--un-gz " + output["unmapped_reads"][0],
+        umapped_string=lambda wildcards, output: (
+            "--un-conc-gz "
+            + output["unmapped_reads"][0].replace(".R1.fastq.gz", ".R%.fastq.gz")
+            if is_paired()
+            else "--un-gz " + output["unmapped_reads"][0]
+        ),
         db_prefix=lambda wildcards, input: os.path.splitext(
             os.path.splitext(input.idx[0])[0]
         )[0],
         extra="",  # optional parameters
-        input_string=lambda wildcards, input: f"-1 {input.R1} -2 {input.R2}"
-        if is_paired()
-        else f"-U {input.R1}",
+        input_string=lambda wildcards, input: (
+            f"-1 {input.R1} -2 {input.R2}" if is_paired() else f"-U {input.R1}"
+        ),
     threads: 16
     resources:
         mem_mb=lambda wc, attempt: 12 * 1024 * attempt,
@@ -161,9 +163,11 @@ rule s03_get_unmapped:
         ),
         flagstat=temp(f"02-snap/{{sample}}.{snap_human_db_name}.bam.flagstat"),
     params:
-        bamtofastq_outputstring=lambda wc, output: f"-1 {output.unmapped_reads[0]} -2 {output.unmapped_reads[1]}"
-        if is_paired()
-        else f"-0 {output.unmapped_reads[0]}",
+        bamtofastq_outputstring=lambda wc, output: (
+            f"-1 {output.unmapped_reads[0]} -2 {output.unmapped_reads[1]}"
+            if is_paired()
+            else f"-0 {output.unmapped_reads[0]}"
+        ),
         # bamtofastq_outputstring=lambda wc, output: f"-fq {output.unmapped_reads[0]} -fq2 {output.unmapped_reads[1]}"
         # if is_paired()
         # else f"-fq {output.unmapped_reads[0]}",

--- a/workflow/rules/preprocess.smk
+++ b/workflow/rules/preprocess.smk
@@ -117,12 +117,16 @@ rule bbmap_dedup:
     params:
         allowed_subs=3,
         flags=lambda wc: bbmap_dedup_params_flags(wc, config),
-        inputstring=lambda wc, input: f"in={input.reads[0]} in2={input.reads[1]}"
-        if is_paired()
-        else f"in={input.reads[0]}",
-        outputstring=lambda wc, output: f"out={output.reads[0]} out2={output.reads[1]}"
-        if is_paired()
-        else f"out={output.reads[0]}",
+        inputstring=lambda wc, input: (
+            f"in={input.reads[0]} in2={input.reads[1]}"
+            if is_paired()
+            else f"in={input.reads[0]}"
+        ),
+        outputstring=lambda wc, output: (
+            f"out={output.reads[0]} out2={output.reads[1]}"
+            if is_paired()
+            else f"out={output.reads[0]}"
+        ),
     threads: 8
     resources:
         mem_mb=lambda wildcards, input, attempt: attempt
@@ -188,9 +192,11 @@ use rule split_fastq from utils as utils_split_fastq with:
         o="logs/split_fastq_{sample}.o",
     params:
         outdir=lambda wc, output: os.path.dirname(output.reads[0]),
-        inputstring=lambda wc, input: f"--read1 {input['R1']} --read2 {input['R2']}"
-        if is_paired()
-        else f"--read1 {input['R1']}",
+        inputstring=lambda wc, input: (
+            f"--read1 {input['R1']} --read2 {input['R2']}"
+            if is_paired()
+            else f"--read1 {input['R1']}"
+        ),
         nshards=config["nshards"],
 
 
@@ -216,15 +222,21 @@ rule bbmap_run:
     threads: 8
     params:
         filter_params=config["filter_params"],
-        inputstring=lambda wc, input: f"in={input['R1']} in2={input['R2']}"
-        if is_paired()
-        else f"in={input['R1']}",
-        outputstring=lambda wc, output: f"out={output.reads[0]} out2={output.reads[1]}"
-        if is_paired()
-        else f"out={output.reads[0]}",
-        outputrmstring=lambda wc, output: f"outm={output.rm_reads[0]} outm2={output.rm_reads[1]}"
-        if is_paired()
-        else f"outm={output.rm_reads[0]}",
+        inputstring=lambda wc, input: (
+            f"in={input['R1']} in2={input['R2']}"
+            if is_paired()
+            else f"in={input['R1']}"
+        ),
+        outputstring=lambda wc, output: (
+            f"out={output.reads[0]} out2={output.reads[1]}"
+            if is_paired()
+            else f"out={output.reads[0]}"
+        ),
+        outputrmstring=lambda wc, output: (
+            f"outm={output.rm_reads[0]} outm2={output.rm_reads[1]}"
+            if is_paired()
+            else f"outm={output.rm_reads[0]}"
+        ),
     resources:
         mem_mb=4000,
     container:
@@ -369,9 +381,11 @@ rule aligned_host_reads_to_fastq:
     params:
         # we pipe the output from single-end runs to hopefully avoid any issues
         # with the pairing flags that may or may not be set in true single-end data
-        bamtofastq_outputstring=lambda wc, output: f"-1 {output.reads[0]} -2 {output.reads[1]}"
-        if is_paired()
-        else f"> {output.reads[0]}",
+        bamtofastq_outputstring=lambda wc, output: (
+            f"-1 {output.reads[0]} -2 {output.reads[1]}"
+            if is_paired()
+            else f"> {output.reads[0]}"
+        ),
         # bamtofastq_outputstring=lambda wc, output: f"-fq {output.unmapped_reads[0]} -fq2 {output.unmapped_reads[1]}"
         # if is_paired()
         # else f"-fq {output.unmapped_reads[0]}",
@@ -437,9 +451,11 @@ rule sortmerna_run:
         aligned_prefix=lambda wildcards, output: output["blast"].replace(
             ".blast.gz", ""
         ),
-        inputstring=lambda wc, input: f"--reads {input['R1']} --reads {input['R1']}"
-        if is_paired()
-        else f"--reads {input['R1']}",
+        inputstring=lambda wc, input: (
+            f"--reads {input['R1']} --reads {input['R1']}"
+            if is_paired()
+            else f"--reads {input['R1']}"
+        ),
     resources:
         mem_mb=lambda wc, attempt: 6 * 1024 * attempt,
         runtime=lambda wc, attempt: 2 * 60 * attempt * attempt * attempt,

--- a/workflow/rules/utils.smk
+++ b/workflow/rules/utils.smk
@@ -8,9 +8,11 @@ rule split_fastq:
         reads=[],
     params:
         outdir=lambda wc, output: os.path.dirname(output.reads[0]),
-        inputstring=lambda wc, input: f"--read1 {input['R1']} --read2 {input['R2']}"
-        if is_paired()
-        else f"--read1 {input['R1']}",
+        inputstring=lambda wc, input: (
+            f"--read1 {input['R1']} --read2 {input['R2']}"
+            if is_paired()
+            else f"--read1 {input['R1']}"
+        ),
         nshards=1,
     container:
         "docker://pegi3s/seqkit:2.3.0"
@@ -59,6 +61,7 @@ rule concat_lanes_fix_names:
       any standard sample name /file name relationship.
     - this is also a "convenient" place to deal with non-gzipped files. default is frmt is "gz"
     """
+
     #
     input:
         fq=[],


### PR DESCRIPTION
This PR is still currently in progress, I want it to pass some more tests before it is ready to merge.  Curently it is passing sanity check runs with local tests.  I am kicking off more tests outside of `isabl` to make sure that the humann outputs from this new version match with our previous version before this is ready to merge (will add results here). 

One thing to be aware of is that the current workflow applies thresholds like this:

nuc align -> nuc thresholds
translated_align -> translated thresholds

But, because we join these files then rerun them, our threshold application will actually look like this: 

nuc_align -> nuc_tresholds -> translated_thresholds.
translated_align -> translated thresholds

Given that these [thresholds are not necessarily the same](https://github.com/biobakery/humann/blob/a9f181f32b3c66b66b73cabc611ff3ac55d87033/humann/config.py#L256), this opens us up for outputs to change.  The tests should hopefully help us see how much of an issue this actually ends up being though. On the plus side, since thresholds are applied at the `unaligned_reads` call of either the nucleotide or translated alignments, I actually think that might mean we can consider just joining the gene tables of both outputs instead (ie the nuc alone and then the translated reads along without merging in the nuc aligned results first). (if this version doesn't work). 