### PR TITLE
Alignment should be done on full assembly not shards

### DIFF
--- a/workflow/rules/annotate.smk
+++ b/workflow/rules/annotate.smk
@@ -41,6 +41,7 @@ outputs = [
     f"{config['sample']}_cazi_overview.txt",
     f"{config['sample']}_cazi_substrate.out",
     f"{config['sample']}_annotated_cazymes_RPM.tsv",
+    f"{config['sample']}_metawrap_{config["metawrap_compl_thresh"]}_{config["metawrap_contam_thresh"]}_coverage_mqc.tsv'
     abricates,
 ]
 if config["check_contigs"]:
@@ -394,7 +395,7 @@ rule coverm:
         R2=config["R2"],
         mag=f"{config['sample']}_metaerg.ffn",
     output:
-        mqc=f'coverm/{{sample}}_metawrap_{config["metawrap_compl_thresh"]}_{config["metawrap_contam_thresh"]}_coverage_mqc.tsv',
+        mqc= f"{config['sample']}_metawrap_{config["metawrap_compl_thresh"]}_{config["metawrap_contam_thresh"]}_coverage_mqc.tsv',
         bams=directory(
             f'coverm/{{sample}}_metawrap_{config["metawrap_compl_thresh"]}_{config["metawrap_contam_thresh"]}_bams/'
         ),

--- a/workflow/rules/annotate.smk
+++ b/workflow/rules/annotate.smk
@@ -290,11 +290,11 @@ rule join_metaerg_outputs:
 
 rule align_annotated_genes:
     input:
-        ffn="annotation/annotation_{batch}/data/cds.ffn",
+        ffn=f"{config['sample']}_metaerg.ffn",
         r1=config["R1"],
         r2=config["R2"],
     output:
-        bamfile="annotation/annotation_{batch}/aligned_reads.bam",
+        bamfile=f"{config['sample']}_metaerg_aligned_reads.bam",
     container:
         config["docker_bowtie2"]
     resources:
@@ -303,8 +303,8 @@ rule align_annotated_genes:
         threads=16,
         cores=16,
     params:
-        bowtie_dir="annotation/annotation_{batch}/bowtie",
-        bowtie_index="annotation/annotation_{batch}/bowtie/bowtie2_index",
+        bowtie_dir="metaerg_bowtie_align",
+        bowtie_index="metaerg_bowtie_align/bowtie2_index",
     shell:
         """
         mkdir -p {params.bowtie_dir}
@@ -318,10 +318,10 @@ rule align_annotated_genes:
 
 rule seqkit_annotate_ffn:
     input:
-        ffn="annotation/annotation_{batch}/data/cds.ffn",
+        ffn=f"{config['sample']}_metaerg.ffn",
     output:
-        length_file="annotation/annotation_{batch}/seqkit.length",
-        bed_file="annotation/annotation_{batch}/seqkit.bed",
+        length_file="seqkit.length",
+        bed_file="seqkit.bed",
     container:
         config["docker_seqkit"]
     shell:
@@ -333,11 +333,11 @@ rule seqkit_annotate_ffn:
 
 rule bedtools_coverage:
     input:
-        length_file="annotation/annotation_{batch}/seqkit.length",
-        bed_file="annotation/annotation_{batch}/seqkit.bed",
-        bamfile="annotation/annotation_{batch}/aligned_reads.bam",
+        length_file="seqkit.length",
+        bed_file="seqkit.bed",
+        bamfile=f"{config['sample']}_metaerg_aligned_reads.bam",
     output:
-        coverage="annotation/annotation_{batch}/annotated_gene_coverage.txt",
+        coverage="annotated_gene_coverage.txt",
     container:
         config["docker_bedtools"]
     shell:
@@ -346,32 +346,16 @@ rule bedtools_coverage:
         """
 
 
-rule create_RPM_counts:
-    input:
-        coverage="annotation/annotation_{batch}/annotated_gene_coverage.txt",
-        overview="cazi_db_scan/{batch}/overview.txt",
-        substrate="cazi_db_scan/{batch}/substrate.out",
-        cgc="cazi_db_scan/{batch}/cgc.out",
-        r1=config["R1"],
-    output:
-        rpm_file="cazi_db_scan/{batch}/annoted_cazymes_RPM.tsv",
-    conda:
-        "../envs/annotate_output_parse.yaml"
-    script:
-        "../scripts/generate_RPM_annotation_files.py"
-
 
 rule join_CAZI:
     input:
         overview=expand("cazi_db_scan/{batch}/overview.txt", batch=BATCHES),
         substrate=expand("cazi_db_scan/{batch}/substrate.out", batch=BATCHES),
         cgc=expand("cazi_db_scan/{batch}/cgc.out", batch=BATCHES),
-        rpm=expand("cazi_db_scan/{batch}/annoted_cazymes_RPM.tsv", batch=BATCHES),
     output:
         overview=f"{config['sample']}_cazi_overview.txt",
         substrate=f"{config['sample']}_cazi_substrate.out",
         cgc=f"{config['sample']}_cazi_cgc.out",
-        rpm=f"{config['sample']}_annotated_cazymes_RPM.tsv",
     shell:
         """
         join_files(){{
@@ -389,5 +373,20 @@ rule join_CAZI:
         join_files {output.overview} {input.overview}
         join_files {output.substrate} {input.substrate}
         join_files {output.cgc} {input.cgc}
-        join_files {output.rpm} {input.rpm}
         """
+
+
+
+rule create_RPM_counts:
+    input:
+        coverage="annotated_gene_coverage.txt",
+        overview=f"{config['sample']}_cazi_overview.txt",
+        substrate=f"{config['sample']}_cazi_substrate.out",
+        cgc=f"{config['sample']}_cazi_cgc.out",
+        r1=config["R1"],
+    output:
+        rpm_file="cazi_db_scan/{batch}/annoted_cazymes_RPM.tsv",
+    conda:
+        "../envs/annotate_output_parse.yaml"
+    script:
+        "../scripts/generate_RPM_annotation_files.py"

--- a/workflow/rules/annotate.smk
+++ b/workflow/rules/annotate.smk
@@ -375,7 +375,56 @@ rule join_CAZI:
         join_files {output.cgc} {input.cgc}
         """
 
+rule coverm:
+    """ This calculates contig coverage.  
 
+    specifying inputs with --coupled and -1 -2 seem to give equivalent results.
+    Note that the output only refers tothe forward file as the sample name.
+    minimap2 is supposedly faster and more accurate than BWA, so we use that
+    as the mapper.
+    we return all the available methods as of the time of writing this rule
+    except for coverage_histogram which has to run separately
+    ("Cannot specify the coverage_histogram method with any other coverage methods")
+
+    --min-covered-fraction is required to be set to 0 for certain cov metrics
+     --genome-fasta-extension is fa since thats how metawrap outputs it
+    """
+    input:
+        R1=config["R1"],
+        R2=config["R2"],
+        mag=f"{config['sample']}_metaerg.ffn",
+    output:
+        mqc=f'coverm/{{sample}}_metawrap_{config["metawrap_compl_thresh"]}_{config["metawrap_contam_thresh"]}_coverage_mqc.tsv',
+        bams=directory(
+            f'coverm/{{sample}}_metawrap_{config["metawrap_compl_thresh"]}_{config["metawrap_contam_thresh"]}_bams/'
+        ),
+    params:
+        fastq_string=lambda wc, input: " ".join(
+            [
+                config["R1"][x] + " " + config["R2"][x]
+                for x in range(0, len(config["R1"]))
+            ]
+        ),
+    container:
+        config["docker_coverm"]
+    threads: 16
+    shell:
+        """
+        coverm contig \
+          --coupled {params.fastq_string} \
+          -r {input.mag}
+          --mapper minimap2-sr \
+          --methods mean relative_abundance trimmed_mean \
+            covered_bases variance length count reads_per_base rpkm tpm \
+          --output-file {output.mqc}.tmp --threads {threads} \
+          --bam-file-cache-directory {output.bams} \
+          --min-covered-fraction 0 \
+          --genome-fasta-extension fa
+        # add in the Multiqc header info
+        echo -e "# plot_type: 'table'\n# section_name: 'Bin Coverage Statistics'" > {output.mqc}
+        cat {output.mqc}.tmp >> {output.mqc}
+        rm {output.mqc}.tmp
+        """
 
 rule create_RPM_counts:
     input:

--- a/workflow/rules/annotate.smk
+++ b/workflow/rules/annotate.smk
@@ -385,7 +385,7 @@ rule create_RPM_counts:
         cgc=f"{config['sample']}_cazi_cgc.out",
         r1=config["R1"],
     output:
-        rpm_file="cazi_db_scan/{batch}/annoted_cazymes_RPM.tsv",
+        rpm_file=f"{config['sample']}_annotated_cazymes_RPM.tsv",
     conda:
         "../envs/annotate_output_parse.yaml"
     script:

--- a/workflow/rules/annotate.smk
+++ b/workflow/rules/annotate.smk
@@ -41,7 +41,7 @@ outputs = [
     f"{config['sample']}_cazi_overview.txt",
     f"{config['sample']}_cazi_substrate.out",
     f"{config['sample']}_annotated_cazymes_RPM.tsv",
-    f"{config['sample']}_metawrap_{config["metawrap_compl_thresh"]}_{config["metawrap_contam_thresh"]}_coverage_mqc.tsv'
+    f"{config['sample']}_metawrap_coverage_mqc.tsv'
     abricates,
 ]
 if config["check_contigs"]:
@@ -395,7 +395,7 @@ rule coverm:
         R2=config["R2"],
         mag=f"{config['sample']}_metaerg.ffn",
     output:
-        mqc= f"{config['sample']}_metawrap_{config["metawrap_compl_thresh"]}_{config["metawrap_contam_thresh"]}_coverage_mqc.tsv',
+        mqc= f"{config['sample']}_metawrap_coverage_mqc.tsv',
         bams=directory(
             f'coverm/{{sample}}_metawrap_{config["metawrap_compl_thresh"]}_{config["metawrap_contam_thresh"]}_bams/'
         ),

--- a/workflow/rules/annotate.smk
+++ b/workflow/rules/annotate.smk
@@ -410,9 +410,9 @@ rule coverm:
     threads: 16
     shell:
         """
-        coverm contig \
+        coverm genome \
           --coupled {params.fastq_string} \
-          -r {input.mag}
+          -f {input.mag}
           --mapper minimap2-sr \
           --methods mean relative_abundance trimmed_mean \
             covered_bases variance length count reads_per_base rpkm tpm \

--- a/workflow/rules/annotate.smk
+++ b/workflow/rules/annotate.smk
@@ -41,7 +41,7 @@ outputs = [
     f"{config['sample']}_cazi_overview.txt",
     f"{config['sample']}_cazi_substrate.out",
     f"{config['sample']}_annotated_cazymes_RPM.tsv",
-    f"{config['sample']}_metawrap_coverage_mqc.tsv'
+    f"{config['sample']}_metawrap_coverage_mqc.tsv',
     abricates,
 ]
 if config["check_contigs"]:


### PR DESCRIPTION
Realized that we were performing alignment on each shard, rather than on the full assembly.  Given that some Cazyme genes may be somewhat degenerate, I am concerned that this may be causing us to over-inflate our RPM estimates. Will test a few samples with `isabl` before this is ready for merging. 